### PR TITLE
Add GitHub Skills activity

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -51,6 +51,12 @@ activities = {
         "max_participants": 15,
         "participants": ["ava@mergington.edu", "mia@mergington.edu"]
     },
+    "GitHub Skills": {
+        "description": "Learn practical coding and collaboration skills through GitHub's certification program",
+        "schedule": "Mondays and Thursdays, 4:00 PM - 5:30 PM",
+        "max_participants": 25,
+        "participants": []
+    },
     "Art Club": {
         "description": "Explore your creativity through painting and drawing",
         "schedule": "Thursdays, 3:30 PM - 5:00 PM",


### PR DESCRIPTION
Resolves #6

Added the GitHub Skills activity to the available activities list with:
- Description referencing the GitHub Certifications program
- Schedule: Mondays and Thursdays, 4:00 PM - 5:30 PM
- Capacity for 25 participants
- Ready for immediate registration

This is a time-sensitive addition as registrations close this week. The activity is now available for students to sign up through the regular registration process.